### PR TITLE
Remove Title Button Focus State on Click

### DIFF
--- a/configuration-frontend/js/directives/header.js
+++ b/configuration-frontend/js/directives/header.js
@@ -2,9 +2,13 @@ TwitchOverlay.directive('header', ['TwitchOverlayServer', function(TwitchOverlay
     return {
         restrict: 'E',
         templateUrl: 'configuration-frontend/templates/directives/header.html',
-        link: function($scope) {
+        link: function($scope, element) {
             var gui = require('nw.gui');
             var win = gui.Window.get();
+
+            element.on("click", function(event) {
+                element.find("button:focus").blur();
+            });
 
             $scope.goFullscreen = function() {
                 win.toggleFullscreen();


### PR DESCRIPTION
This fixes a bug where buttons appear dark grey after closing the console or maximizing the window.